### PR TITLE
feat: Allow empty registry directory before cloning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+.registry

--- a/api-server/apiserver.py
+++ b/api-server/apiserver.py
@@ -55,7 +55,7 @@ class Git(object):
         p.wait()
 
     def init(self):
-        if not os.path.exists(self.path):
+        if not os.path.exists(self.path) or not os.listdir(self.path):
             self._git(['clone', self.remote, self.path], cwd=None)
 
     def pull(self):


### PR DESCRIPTION
Useful when we mount `.registry` as a Docker volume.