### PR TITLE
docs: Add links to external references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Sentry Release Registry
 
-This is a meta repository holding all release information. This replaces the
-mess we had before where release infos were in different locations. This is used
-by the new SDK docs as well as Sentry's loader itself.
+This is a meta repository holding release information for Sentry repositories.
+
+It centralizes information that used to be in different locations. It is used by
+the [SDK docs][sdk-docs] and the [Sentry Loader for JavaScript][js-loader].
+
+[sdk-docs]: https://github.com/getsentry/sentry-docs/
+[js-loader]: https://docs.sentry.io/platforms/javascript/#lazy-loading-sentry
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 This is a meta repository holding release information for Sentry repositories.
 
-It centralizes information that used to be in different locations. It is used by
-the [SDK docs][sdk-docs] and the [Sentry Loader for JavaScript][js-loader].
+It centralizes information that used to be in different locations. It is known
+to be used by at least:
+
+- The [SDK docs][sdk-docs]
+- The [Sentry Loader for JavaScript][js-loader]
+- The [SDK update prompt][sdk-update-prompt] in Sentry event pages
 
 [sdk-docs]: https://github.com/getsentry/sentry-docs/
 [js-loader]: https://docs.sentry.io/platforms/javascript/#lazy-loading-sentry
+[sdk-update-prompt]: https://github.com/getsentry/sentry/blob/ea791cb482d6f77481beed41e64ccc52ce10bc65/src/sentry/sdk_updates.py
 
 ## Layout
 


### PR DESCRIPTION
This is with the intention of making it clear what the reference is about without requiring implicit prior knowledge.