### PR TITLE
fix: Only remove symlinks to *.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 remove-package-links:
-	rm -f $$(find apps/ packages/ -type l)
+	rm -f $$(find apps/ packages/ -type l -name '*.json')
 .PHONY: remove-package-links
 
 sync-all-links: remove-package-links
-	bin/sync-links $$(find apps/ packages/ sdks/ -type f | grep json)
+	bin/sync-links $$(find apps/ packages/ sdks/ -type f -name '*.json')
 .PHONY: sync-all-links


### PR DESCRIPTION
There is a symlink at `packages/composer/@sentry -> packages/composer/sentry` that was being incorrectly removed via make.

Since we're updating the call to `find`, also update the `find` usage in `sync-all-links`.