### PR TITLE
ci: Ensure symlinks are kept in sync

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,14 @@ jobs:
           TARGET: lint
 
     steps:
-      - script: |
+      - bash: |
           set -eux
+
+          # Ensure symlinks are synced
+          make sync-all-links
+          if [ "$(git status --porcelain)" ]; then
+            echo 'Symlinks out-of-sync. Please run "make sync-all-links" and update your commit.'
+            exit 1
+          fi
 
           ./api-server/bin/test-utils/docker-run-tests


### PR DESCRIPTION
Ensuring in CI that `make sync-all-links` was run and symlinks were committed will prevent future occurrences of problems like the ones fixed in #21, #22 and #23 to repeat again.