### PR TITLE
docs: Fix instruction to add New SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ on unix platforms.
    }
    ```
 
-3. `cd sdks/ && ln -s ./packages/<registry>/<package_name> ./<sdk_name>`
+3. `cd sdks && ln -s ../packages/<registry>/<package_name> <sdk_name>`
 
    - `<sdk_name>`: The same identifier used in the `sdk_info.name` field of the
      event.


### PR DESCRIPTION
After `cd`'ing into the `sdk` directory, the `packages` directory is `../packages`, not `./packages`.

Further simplify the line by removing the trailing slash from `sdks` and the dot-slash before `<sdk_name>`.

Clarifies the question in https://github.com/getsentry/sentry-release-registry/pull/15#discussion_r379468498.