### PR TITLE
fix: main_docs_url for sentry-cocoa 5.x.x

### DIFF
--- a/packages/cocoapods/sentry-cocoa/5.0.0-beta.6.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.0-beta.6.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.0-beta.6",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.0.0-rc.1.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.0-rc.1.json
@@ -3,6 +3,6 @@
     "canonical": "cocoapods:sentry-cocoa",
     "version": "5.0.0-rc.1",
     "repo_url": "https://github.com/getsentry/sentry-cocoa",
-    "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+    "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
   }
   

--- a/packages/cocoapods/sentry-cocoa/5.0.0.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.0.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.0",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.0.1.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.1.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.1",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.0.2.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.2.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.2",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.0.3.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.3.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.3",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.0.4.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.4.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.4",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.0.5.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.5.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.5",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.0.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.0.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.0",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.1.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.1.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.1",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.10-beta.0.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.10-beta.0.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.10-beta.0",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.2.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.2.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.2",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.3.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.3.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.3",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.4.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.4.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.4",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.5.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.5.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.5",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.6.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.6.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.6",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.7.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.7.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.7",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.8.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.8.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.8",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }

--- a/packages/cocoapods/sentry-cocoa/5.1.9.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.9.json
@@ -3,5 +3,5 @@
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.9",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
-  "main_docs_url": "https://docs.sentry.io/clients/cocoa"
+  "main_docs_url": "https://docs.sentry.io/platforms/cocoa/"
 }


### PR DESCRIPTION
The `main_docs_url` for sentry-cocoa releases 5.x.x pointed to the old https://docs.sentry.io/clients/cocoa version of the docs. Now they point to https://docs.sentry.io/platforms/cocoa/