### PR TITLE
feat: Add base file for AWS Lambda node layers

### DIFF
--- a/aws-lambda-layers/node/base.json
+++ b/aws-lambda-layers/node/base.json
@@ -1,0 +1,5 @@
+{
+  "name": "AWS Lambda Node Layer",
+  "repo_url": "https://github.com/getsentry/sentry-javascript",
+  "main_docs_url": "https://docs.sentry.io/platforms/node/guides/aws-lambda"
+}


### PR DESCRIPTION
Craft will automatically update new AWS Lambda layer info when publishing.

- Craft creates new files, but does not create new directories. Thus, the directories are created in this PR.
- The `base.json` file, specific to a runtime, contains static data fields that every version file will contain. Version files will contain the same structure as https://github.com/getsentry/sentry-release-registry/pull/30.