### PR TITLE
feat(aws-lambda): adds route for aws layer

### DIFF
--- a/api-server/apiserver.py
+++ b/api-server/apiserver.py
@@ -193,7 +193,6 @@ class Registry(object):
                 continue
         return rv
 
-
     def get_apps(self):
         rv = {}
         for link in os.listdir(self._path('apps')):
@@ -374,5 +373,6 @@ def healthcheck():
 @app.route('/aws-lambda-layers')
 def aws_layers():
     return ApiResponse(registry.get_aws_lambda_layers())
+
 
 registry = Registry()

--- a/api-server/apiserver.py
+++ b/api-server/apiserver.py
@@ -182,6 +182,18 @@ class Registry(object):
         except (IOError, OSError):
             pass
 
+    def get_aws_lambda_layers(self):
+        rv = {}
+        for link in os.listdir(self._path('aws-lambda-layers')):
+            try:
+                with open(self._path('aws-lambda-layers', link, 'latest.json')) as f:
+                    data = json.load(f)
+                    rv[data["canonical"]] = data
+            except (IOError, OSError):
+                continue
+        return rv
+
+
     def get_apps(self):
         rv = {}
         for link in os.listdir(self._path('apps')):
@@ -358,5 +370,9 @@ def get_app_version(app_id, version):
 def healthcheck():
     return "ok\n", 200
 
+
+@app.route('/aws-lambda-layers')
+def aws_layers():
+    return ApiResponse(registry.get_aws_lambda_layers())
 
 registry = Registry()


### PR DESCRIPTION
This PR adds a route so we can read the AWS Lambda layer latest version. This will be used in an upcoming Sentry PR: https://github.com/getsentry/sentry/pull/23036