### PR TITLE
fix: Revert maven canonicals and allow colons as path separators

### DIFF
--- a/api-server/apiserver.py
+++ b/api-server/apiserver.py
@@ -125,10 +125,12 @@ class Registry(object):
         return os.path.join(self.path, *args)
 
     def get_package(self, canonical, version='latest'):
-        """Looks up a package by canonical version"""
+        """Looks up a package by its canonical name and version"""
         if ':' not in canonical:
             return
         registry, package = canonical.split(':', 1)
+        # Allow ":" to be used as a path separator
+        package = package.replace(":", "/")
         try:
             path = self._path('packages', registry, package, '%s.json' % version)
             with open(path) as f:

--- a/api-server/tests/test_routes.py
+++ b/api-server/tests/test_routes.py
@@ -26,6 +26,8 @@ def test_route_sdks(client, sdks_url):
     assert response.status_code == 200
     data = response.get_json()
     assert data['sentry.python']['canonical'] == 'pypi:sentry-sdk'
+    # ":" should work properly as a separator
+    assert data['sentry.java']['canonical'] == 'maven:io.sentry:sentry'
 
 
 def test_routes_sdk_single_latest(client):
@@ -50,6 +52,8 @@ def test_route_packages(client, packages_url):
     assert response.status_code == 200
     data = response.get_json()
     assert data['pypi:sentry-sdk']['canonical'] == 'pypi:sentry-sdk'
+    # ":" should work properly as a separator
+    assert data['maven:io.sentry:sentry']['canonical'] == 'maven:io.sentry:sentry'
 
 
 def test_route_apps(client):

--- a/packages/maven/io.sentry/sentry-android-core/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-android-core/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-android-core",
-    "canonical": "maven:io.sentry/sentry-android-core",
+    "canonical": "maven:io.sentry:sentry-android-core",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-android-core",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-android-gradle-plugin/1.7.36.json
+++ b/packages/maven/io.sentry/sentry-android-gradle-plugin/1.7.36.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-android-gradle-plugin",
-    "canonical": "maven:io.sentry/sentry-android-gradle-plugin",
+    "canonical": "maven:io.sentry:sentry-android-gradle-plugin",
     "version": "1.7.36",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-android-gradle-plugin",
     "repo_url": "https://github.com/getsentry/sentry-android-gradle-plugin",

--- a/packages/maven/io.sentry/sentry-android-ndk/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-android-ndk/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-android-ndk",
-    "canonical": "maven:io.sentry/sentry-android-ndk",
+    "canonical": "maven:io.sentry:sentry-android-ndk",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-android-ndk",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-android-timber/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-android-timber/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-android-timber",
-    "canonical": "maven:io.sentry/sentry-android-timber",
+    "canonical": "maven:io.sentry:sentry-android-timber",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-android-timber",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-android/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-android/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-android",
-    "canonical": "maven:io.sentry/sentry-android",
+    "canonical": "maven:io.sentry:sentry-android",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-android",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-apache-http-client-5/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-apache-http-client-5/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-apache-http-client-5",
-    "canonical": "maven:io.sentry/sentry-apache-http-client-5",
+    "canonical": "maven:io.sentry:sentry-apache-http-client-5",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-apache-http-client-5",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-jul/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-jul/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-jul",
-    "canonical": "maven:io.sentry/sentry-jul",
+    "canonical": "maven:io.sentry:sentry-jul",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-jul",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-log4j2/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-log4j2/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-log4j2",
-    "canonical": "maven:io.sentry/sentry-log4j2",
+    "canonical": "maven:io.sentry:sentry-log4j2",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-log4j2",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-logback/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-logback/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-logback",
-    "canonical": "maven:io.sentry/sentry-logback",
+    "canonical": "maven:io.sentry:sentry-logback",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-logback",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-servlet/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-servlet/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-servlet",
-    "canonical": "maven:io.sentry/sentry-servlet",
+    "canonical": "maven:io.sentry:sentry-servlet",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-servlet",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-spring-boot-starter/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-spring-boot-starter/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-spring-boot-starter",
-    "canonical": "maven:io.sentry/sentry-spring-boot-starter",
+    "canonical": "maven:io.sentry:sentry-spring-boot-starter",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-spring-boot-starter",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry-spring/4.1.0.json
+++ b/packages/maven/io.sentry/sentry-spring/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry-spring",
-    "canonical": "maven:io.sentry/sentry-spring",
+    "canonical": "maven:io.sentry:sentry-spring",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry-spring",
     "repo_url": "https://github.com/getsentry/sentry-java",

--- a/packages/maven/io.sentry/sentry/4.1.0.json
+++ b/packages/maven/io.sentry/sentry/4.1.0.json
@@ -1,6 +1,6 @@
 {
     "name": "io.sentry:sentry",
-    "canonical": "maven:io.sentry/sentry",
+    "canonical": "maven:io.sentry:sentry",
     "version": "4.1.0",
     "package_url": "https://search.maven.org/artifact/io.sentry/sentry",
     "repo_url": "https://github.com/getsentry/sentry-java",


### PR DESCRIPTION
This partially reverts #44.

Here we add a small hack to allow some ":"s in canonical names to be treated as path separators (mostly to avoid massive fixes in Java SDKs).


