### PR TITLE
fix(link): Update react main_docs_url

### DIFF
--- a/packages/npm/@sentry/react/5.20.0.json
+++ b/packages/npm/@sentry/react/5.20.0.json
@@ -4,5 +4,5 @@
   "version": "5.20.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.20.1.json
+++ b/packages/npm/@sentry/react/5.20.1.json
@@ -4,5 +4,5 @@
   "version": "5.20.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.21.0.json
+++ b/packages/npm/@sentry/react/5.21.0.json
@@ -4,5 +4,5 @@
   "version": "5.21.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.21.1.json
+++ b/packages/npm/@sentry/react/5.21.1.json
@@ -4,5 +4,5 @@
   "version": "5.21.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.21.2.json
+++ b/packages/npm/@sentry/react/5.21.2.json
@@ -4,5 +4,5 @@
   "version": "5.21.2",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.21.3.json
+++ b/packages/npm/@sentry/react/5.21.3.json
@@ -4,5 +4,5 @@
   "version": "5.21.3",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.21.4.json
+++ b/packages/npm/@sentry/react/5.21.4.json
@@ -4,5 +4,5 @@
   "version": "5.21.4",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.22.0.json
+++ b/packages/npm/@sentry/react/5.22.0.json
@@ -4,5 +4,5 @@
   "version": "5.22.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.22.1.json
+++ b/packages/npm/@sentry/react/5.22.1.json
@@ -4,5 +4,5 @@
   "version": "5.22.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.22.2.json
+++ b/packages/npm/@sentry/react/5.22.2.json
@@ -4,5 +4,5 @@
   "version": "5.22.2",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.22.3.json
+++ b/packages/npm/@sentry/react/5.22.3.json
@@ -4,5 +4,5 @@
   "version": "5.22.3",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.23.0.json
+++ b/packages/npm/@sentry/react/5.23.0.json
@@ -4,5 +4,5 @@
   "version": "5.23.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.24.0.json
+++ b/packages/npm/@sentry/react/5.24.0.json
@@ -4,5 +4,5 @@
   "version": "5.24.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.24.1.json
+++ b/packages/npm/@sentry/react/5.24.1.json
@@ -4,5 +4,5 @@
   "version": "5.24.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.24.2.json
+++ b/packages/npm/@sentry/react/5.24.2.json
@@ -4,5 +4,5 @@
   "version": "5.24.2",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.25.0.json
+++ b/packages/npm/@sentry/react/5.25.0.json
@@ -4,5 +4,5 @@
   "version": "5.25.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.26.0.json
+++ b/packages/npm/@sentry/react/5.26.0.json
@@ -4,5 +4,5 @@
   "version": "5.26.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.27.0.json
+++ b/packages/npm/@sentry/react/5.27.0.json
@@ -4,5 +4,5 @@
   "version": "5.27.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.27.1.json
+++ b/packages/npm/@sentry/react/5.27.1.json
@@ -4,5 +4,5 @@
   "version": "5.27.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.27.2.json
+++ b/packages/npm/@sentry/react/5.27.2.json
@@ -4,5 +4,5 @@
   "version": "5.27.2",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.27.3.json
+++ b/packages/npm/@sentry/react/5.27.3.json
@@ -4,5 +4,5 @@
   "version": "5.27.3",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.27.4.json
+++ b/packages/npm/@sentry/react/5.27.4.json
@@ -4,5 +4,5 @@
   "version": "5.27.4",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.27.5.json
+++ b/packages/npm/@sentry/react/5.27.5.json
@@ -4,5 +4,5 @@
   "version": "5.27.5",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.27.6.json
+++ b/packages/npm/@sentry/react/5.27.6.json
@@ -4,5 +4,5 @@
   "version": "5.27.6",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.28.0.json
+++ b/packages/npm/@sentry/react/5.28.0.json
@@ -4,5 +4,5 @@
   "version": "5.28.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.29.0.json
+++ b/packages/npm/@sentry/react/5.29.0.json
@@ -4,5 +4,5 @@
   "version": "5.29.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.29.1.json
+++ b/packages/npm/@sentry/react/5.29.1.json
@@ -4,5 +4,5 @@
   "version": "5.29.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.29.2.json
+++ b/packages/npm/@sentry/react/5.29.2.json
@@ -4,5 +4,5 @@
   "version": "5.29.2",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/5.30.0.json
+++ b/packages/npm/@sentry/react/5.30.0.json
@@ -4,5 +4,5 @@
   "version": "5.30.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.0.0.json
+++ b/packages/npm/@sentry/react/6.0.0.json
@@ -4,5 +4,5 @@
   "version": "6.0.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.0.1.json
+++ b/packages/npm/@sentry/react/6.0.1.json
@@ -4,5 +4,5 @@
   "version": "6.0.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.0.2.json
+++ b/packages/npm/@sentry/react/6.0.2.json
@@ -4,5 +4,5 @@
   "version": "6.0.2",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.1.0.json
+++ b/packages/npm/@sentry/react/6.1.0.json
@@ -4,5 +4,5 @@
   "version": "6.1.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.10.0.json
+++ b/packages/npm/@sentry/react/6.10.0.json
@@ -4,5 +4,5 @@
   "version": "6.10.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.11.0.json
+++ b/packages/npm/@sentry/react/6.11.0.json
@@ -4,5 +4,5 @@
   "version": "6.11.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.2.0.json
+++ b/packages/npm/@sentry/react/6.2.0.json
@@ -4,5 +4,5 @@
   "version": "6.2.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.2.1.json
+++ b/packages/npm/@sentry/react/6.2.1.json
@@ -4,5 +4,5 @@
   "version": "6.2.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.2.2.json
+++ b/packages/npm/@sentry/react/6.2.2.json
@@ -4,5 +4,5 @@
   "version": "6.2.2",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.2.3.json
+++ b/packages/npm/@sentry/react/6.2.3.json
@@ -4,5 +4,5 @@
   "version": "6.2.3",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.2.4.json
+++ b/packages/npm/@sentry/react/6.2.4.json
@@ -4,5 +4,5 @@
   "version": "6.2.4",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.2.5.json
+++ b/packages/npm/@sentry/react/6.2.5.json
@@ -4,5 +4,5 @@
   "version": "6.2.5",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.3.0.json
+++ b/packages/npm/@sentry/react/6.3.0.json
@@ -4,5 +4,5 @@
   "version": "6.3.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.3.1.json
+++ b/packages/npm/@sentry/react/6.3.1.json
@@ -4,5 +4,5 @@
   "version": "6.3.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.3.2.json
+++ b/packages/npm/@sentry/react/6.3.2.json
@@ -4,5 +4,5 @@
   "version": "6.3.2",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.3.3.json
+++ b/packages/npm/@sentry/react/6.3.3.json
@@ -4,5 +4,5 @@
   "version": "6.3.3",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.3.4.json
+++ b/packages/npm/@sentry/react/6.3.4.json
@@ -4,5 +4,5 @@
   "version": "6.3.4",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.3.5.json
+++ b/packages/npm/@sentry/react/6.3.5.json
@@ -4,5 +4,5 @@
   "version": "6.3.5",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.3.6.json
+++ b/packages/npm/@sentry/react/6.3.6.json
@@ -4,5 +4,5 @@
   "version": "6.3.6",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.4.0.json
+++ b/packages/npm/@sentry/react/6.4.0.json
@@ -4,5 +4,5 @@
   "version": "6.4.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.4.1.json
+++ b/packages/npm/@sentry/react/6.4.1.json
@@ -4,5 +4,5 @@
   "version": "6.4.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.5.1.json
+++ b/packages/npm/@sentry/react/6.5.1.json
@@ -4,5 +4,5 @@
   "version": "6.5.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.6.0.json
+++ b/packages/npm/@sentry/react/6.6.0.json
@@ -4,5 +4,5 @@
   "version": "6.6.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.7.0.json
+++ b/packages/npm/@sentry/react/6.7.0.json
@@ -4,5 +4,5 @@
   "version": "6.7.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.7.1.json
+++ b/packages/npm/@sentry/react/6.7.1.json
@@ -4,5 +4,5 @@
   "version": "6.7.1",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.7.2.json
+++ b/packages/npm/@sentry/react/6.7.2.json
@@ -4,5 +4,5 @@
   "version": "6.7.2",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.8.0.json
+++ b/packages/npm/@sentry/react/6.8.0.json
@@ -4,5 +4,5 @@
   "version": "6.8.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }

--- a/packages/npm/@sentry/react/6.9.0.json
+++ b/packages/npm/@sentry/react/6.9.0.json
@@ -4,5 +4,5 @@
   "version": "6.9.0",
   "package_url": "https://npmjs.com/package/@sentry/react",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript/react/"
+  "main_docs_url": "https://docs.sentry.io/platforms/javascript/guides/react/"
 }


### PR DESCRIPTION
The current link is broken. This PR fixes the issue.

closes: https://sentry.zendesk.com/agent/tickets/52465