### PR TITLE
ref(link): Update raven main_docs_url

### DIFF
--- a/packages/gem/sentry-raven/3.0.0.json
+++ b/packages/gem/sentry-raven/3.0.0.json
@@ -4,6 +4,6 @@
     "version": "3.0.0",
     "package_url": "https://rubygems.org/gems/sentry-raven",
     "repo_url": "https://github.com/getsentry/raven-ruby",
-    "main_docs_url": "https://docs.sentry.io/platforms/ruby"
+    "main_docs_url": "https://docs.sentry.io/platforms/ruby/migration/"
   }
   

--- a/packages/gem/sentry-raven/3.0.1.json
+++ b/packages/gem/sentry-raven/3.0.1.json
@@ -4,5 +4,5 @@
   "version": "3.0.1",
   "package_url": "https://rubygems.org/gems/sentry-raven",
   "repo_url": "https://github.com/getsentry/raven-ruby",
-  "main_docs_url": "https://docs.sentry.io/platforms/ruby"
+  "main_docs_url": "https://docs.sentry.io/platforms/ruby/migration/"
 }

--- a/packages/gem/sentry-raven/3.0.2.json
+++ b/packages/gem/sentry-raven/3.0.2.json
@@ -4,5 +4,5 @@
   "version": "3.0.2",
   "package_url": "https://rubygems.org/gems/sentry-raven",
   "repo_url": "https://github.com/getsentry/raven-ruby",
-  "main_docs_url": "https://docs.sentry.io/platforms/ruby"
+  "main_docs_url": "https://docs.sentry.io/platforms/ruby/migration/"
 }

--- a/packages/gem/sentry-raven/3.0.3.json
+++ b/packages/gem/sentry-raven/3.0.3.json
@@ -4,5 +4,5 @@
   "version": "3.0.3",
   "package_url": "https://rubygems.org/gems/sentry-raven",
   "repo_url": "https://github.com/getsentry/raven-ruby",
-  "main_docs_url": "https://docs.sentry.io/platforms/ruby"
+  "main_docs_url": "https://docs.sentry.io/platforms/ruby/migration/"
 }

--- a/packages/gem/sentry-raven/3.0.4.json
+++ b/packages/gem/sentry-raven/3.0.4.json
@@ -4,5 +4,5 @@
   "version": "3.0.4",
   "package_url": "https://rubygems.org/gems/sentry-raven",
   "repo_url": "https://github.com/getsentry/raven-ruby",
-  "main_docs_url": "https://docs.sentry.io/platforms/ruby"
+  "main_docs_url": "https://docs.sentry.io/platforms/ruby/migration/"
 }

--- a/packages/gem/sentry-raven/3.1.0.json
+++ b/packages/gem/sentry-raven/3.1.0.json
@@ -4,5 +4,5 @@
   "version": "3.1.0",
   "package_url": "https://rubygems.org/gems/sentry-raven",
   "repo_url": "https://github.com/getsentry/raven-ruby",
-  "main_docs_url": "https://docs.sentry.io/platforms/ruby"
+  "main_docs_url": "https://docs.sentry.io/platforms/ruby/migration/"
 }

--- a/packages/gem/sentry-raven/3.1.1.json
+++ b/packages/gem/sentry-raven/3.1.1.json
@@ -4,5 +4,5 @@
   "version": "3.1.1",
   "package_url": "https://rubygems.org/gems/sentry-raven",
   "repo_url": "https://github.com/getsentry/raven-ruby",
-  "main_docs_url": "https://docs.sentry.io/platforms/ruby"
+  "main_docs_url": "https://docs.sentry.io/platforms/ruby/migration/"
 }

--- a/packages/gem/sentry-raven/3.1.2.json
+++ b/packages/gem/sentry-raven/3.1.2.json
@@ -4,5 +4,5 @@
   "version": "3.1.2",
   "package_url": "https://rubygems.org/gems/sentry-raven",
   "repo_url": "https://github.com/getsentry/raven-ruby",
-  "main_docs_url": "https://docs.sentry.io/platforms/ruby"
+  "main_docs_url": "https://docs.sentry.io/platforms/ruby/migration/"
 }

--- a/packages/npm/raven-js/3.27.0.json
+++ b/packages/npm/raven-js/3.27.0.json
@@ -4,5 +4,5 @@
   "version": "3.27.0",
   "package_url": "https://npmjs.com/package/raven-js",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript"
+  "main_docs_url": "https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#migrating-from-raven-js-to-sentrybrowser"
 }

--- a/packages/npm/raven/2.6.4.json
+++ b/packages/npm/raven/2.6.4.json
@@ -4,5 +4,5 @@
   "version": "2.6.4",
   "package_url": "https://npmjs.com/package/raven",
   "repo_url": "https://github.com/getsentry/sentry-javascript",
-  "main_docs_url": "https://docs.sentry.io/platforms/javascript"
+  "main_docs_url": "https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#migrating-from-raven-js-to-sentrybrowser"
 }


### PR DESCRIPTION
Replaces the current link with the link to the migration doc