### PR TITLE
build: move ubuntu to latest for azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ variables:
 jobs:
   - job: Run
     pool:
-      vmImage: "Ubuntu-16.04"
+      vmImage: "ubuntu-latest"
 
     strategy:
       matrix:


### PR DESCRIPTION
The old image is no longer available.