### PR TITLE
Upgrade flask 1.1.0 -> 1.1.4

### DIFF
--- a/api-server/requirements-base.txt
+++ b/api-server/requirements-base.txt
@@ -1,4 +1,4 @@
-flask==1.1.0
+flask==1.4.0
 semver==2.8.1
 sentry-sdk[flask]==0.9.5
 uwsgi==2.0.18

--- a/api-server/requirements-base.txt
+++ b/api-server/requirements-base.txt
@@ -5,3 +5,4 @@ uwsgi==2.0.18
 mywsgi==1.0.3
 Werkzeug==0.16.0
 datadog==0.37.1
+markupsafe==2.0.1

--- a/api-server/requirements-base.txt
+++ b/api-server/requirements-base.txt
@@ -1,4 +1,4 @@
-flask==1.4.0
+flask==1.1.4
 semver==2.8.1
 sentry-sdk[flask]==0.9.5
 uwsgi==2.0.18


### PR DESCRIPTION
The build is currently failing with error:
```
Step 14/17 : RUN flask --version && flask routes
 ---> Running in 77b306b2201c
Traceback (most recent call last):
  File "/usr/local/bin/flask", line 5, in <module>
    from flask.cli import main
  File "/usr/local/lib/python3.7/site-packages/flask/__init__.py", line 19, in <module>
    from . import json
  File "/usr/local/lib/python3.7/site-packages/flask/json/__init__.py", line 15, in <module>
    from itsdangerous import json as _json
ImportError: cannot import name 'json' from 'itsdangerous' (/usr/local/lib/python3.7/site-packages/itsdangerous/__init__.py)
The command '/bin/sh -c flask --version && flask routes' returned a non-zero code: 1
```

This PR implements the fix described in https://serverfault.com/a/1094094/235324