### PR TITLE
feat: Add download support for apps

### DIFF
--- a/api-server/apiserver.py
+++ b/api-server/apiserver.py
@@ -1,18 +1,19 @@
 import os
+import binascii
 from functools import partial
 
 from datadog import initialize as datadog_initialize, statsd
 
 import sentry_sdk
-from flask import Flask, json, abort, jsonify, request
+from flask import Flask, json, abort, jsonify, request, redirect
 from semver import VersionInfo
 from sentry_sdk.integrations.flask import FlaskIntegration
 from werkzeug.contrib.cache import SimpleCache
 
-TRUTHY_VALUES = {'1', 'true', 'yes'}
+TRUTHY_VALUES = {"1", "true", "yes"}
 
 # If this file is present in a subfolder in "packages", that subfolder is a namespace.
-NAMESPACE_FILE_MARKER = '__NAMESPACE__'
+NAMESPACE_FILE_MARKER = "__NAMESPACE__"
 
 
 class Metrics:
@@ -58,9 +59,8 @@ class InvalidPathComponent(ValueError):
 
 
 class RegistryJsonEncoder(json.JSONEncoder):
-
     def default(self, o):
-        if hasattr(o, 'to_json'):
+        if hasattr(o, "to_json"):
             return o.to_json()
         return json.JSONEncoder.default(self, o)
 
@@ -74,48 +74,45 @@ class RegistryFlask(Flask):
         else:
             response = Flask.make_response(self, result)
 
-        response.headers['Access-Control-Allow-Origin'] = '*'
+        response.headers["Access-Control-Allow-Origin"] = "*"
         return response
 
 
 def validate_path_component(path):
     if not path:
-        raise InvalidPathComponent('Invalid path')
-    for item in path.split('/'):
-        if item == '.' or item == '..' or not item:
-            raise InvalidPathComponent('Invalid path %s' % path)
+        raise InvalidPathComponent("Invalid path")
+    for item in path.split("/"):
+        if item == "." or item == ".." or not item:
+            raise InvalidPathComponent("Invalid path %s" % path)
 
 
 class ApiResponse(object):
-
     def __init__(self, data):
         self.data = data
 
 
 class PackageInfo(object):
-
     def __init__(self, registry, data):
         self._registry = registry
         self._data = data
 
     @property
     def canonical(self):
-        return self._data['canonical']
+        return self._data["canonical"]
 
     @property
     def sdk_id(self):
-        return self._data.get('sdk_id')
+        return self._data.get("sdk_id")
 
     @property
     def version(self):
-        return self._data['version']
+        return self._data["version"]
 
     def to_json(self):
         return self._data
 
 
 class Registry(object):
-
     def __init__(self):
         self.path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -124,15 +121,15 @@ class Registry(object):
             validate_path_component(arg)
         return os.path.join(self.path, *args)
 
-    def get_package(self, canonical, version='latest'):
+    def get_package(self, canonical, version="latest"):
         """Looks up a package by its canonical name and version"""
-        if ':' not in canonical:
+        if ":" not in canonical:
             return
-        registry, package = canonical.split(':', 1)
+        registry, package = canonical.split(":", 1)
         # Allow ":" to be used as a path separator
         package = package.replace(":", "/")
         try:
-            path = self._path('packages', registry, package, '%s.json' % version)
+            path = self._path("packages", registry, package, "%s.json" % version)
             with open(path) as f:
                 return PackageInfo(self, json.load(f))
         except (IOError, OSError):
@@ -140,26 +137,33 @@ class Registry(object):
 
     def get_package_versions(self, canonical):
         """Returns all versions of a package."""
-        if ':' not in canonical:
+        if ":" not in canonical:
             return
-        registry, package = canonical.split(':', 1)
+        registry, package = canonical.split(":", 1)
         rv = set()
-        for filename in os.listdir(self._path('packages', registry, package)):
-            if filename.endswith('.json'):
-                with open(self._path('packages', registry, package, filename)) as f:
-                    rv.add(json.load(f)['version'])
+        for filename in os.listdir(self._path("packages", registry, package)):
+            if filename.endswith(".json"):
+                with open(self._path("packages", registry, package, filename)) as f:
+                    rv.add(json.load(f)["version"])
         return sorted(rv, key=VersionInfo.parse)
 
     def iter_packages(self):
-        for package_registry in os.listdir(self._path('packages')):
-            for item in os.listdir(self._path('packages', package_registry)):
-                if os.path.exists(os.path.join(
-                        self._path('packages', package_registry, item, NAMESPACE_FILE_MARKER))):
-                    for subitem in os.listdir(self._path('packages', package_registry, item)):
+        for package_registry in os.listdir(self._path("packages")):
+            for item in os.listdir(self._path("packages", package_registry)):
+                if os.path.exists(
+                    os.path.join(
+                        self._path(
+                            "packages", package_registry, item, NAMESPACE_FILE_MARKER
+                        )
+                    )
+                ):
+                    for subitem in os.listdir(
+                        self._path("packages", package_registry, item)
+                    ):
                         if subitem != NAMESPACE_FILE_MARKER:
-                            yield '%s:%s/%s' % (package_registry, item, subitem)
+                            yield "%s:%s/%s" % (package_registry, item, subitem)
                 else:
-                    yield '%s:%s' % (package_registry, item)
+                    yield "%s:%s" % (package_registry, item)
 
     def get_packages(self, strict=False):
         rv = {}
@@ -167,17 +171,21 @@ class Registry(object):
             pkg = self.get_package(package_name)
             if pkg is None:
                 if strict:
-                    raise ValueError("Package does not exist or invalid canonical: {}".format(package_name))
+                    raise ValueError(
+                        "Package does not exist or invalid canonical: {}".format(
+                            package_name
+                        )
+                    )
             else:
                 rv[pkg.canonical] = pkg
         return rv
 
     def get_sdks(self, strict=False):
         rv = {}
-        for link in os.listdir(self._path('sdks')):
+        for link in os.listdir(self._path("sdks")):
             try:
-                with open(self._path('sdks', link, 'latest.json')) as f:
-                    canonical = json.load(f)['canonical']
+                with open(self._path("sdks", link, "latest.json")) as f:
+                    canonical = json.load(f)["canonical"]
                     pkg = self.get_package(canonical)
                     if pkg is None:
                         if strict:
@@ -192,19 +200,19 @@ class Registry(object):
                 continue
         return rv
 
-    def get_sdk(self, sdk_id, version='latest'):
+    def get_sdk(self, sdk_id, version="latest"):
         try:
-            with open(self._path('sdks', sdk_id, 'latest.json')) as f:
-                canonical = json.load(f)['canonical']
+            with open(self._path("sdks", sdk_id, "latest.json")) as f:
+                canonical = json.load(f)["canonical"]
                 return self.get_package(canonical, version)
         except (IOError, OSError):
             pass
 
     def get_aws_lambda_layers(self):
         rv = {}
-        for link in os.listdir(self._path('aws-lambda-layers')):
+        for link in os.listdir(self._path("aws-lambda-layers")):
             try:
-                with open(self._path('aws-lambda-layers', link, 'latest.json')) as f:
+                with open(self._path("aws-lambda-layers", link, "latest.json")) as f:
                     data = json.load(f)
                     rv[data["canonical"]] = data
             except (IOError, OSError):
@@ -213,7 +221,7 @@ class Registry(object):
 
     def get_apps(self):
         rv = {}
-        for link in os.listdir(self._path('apps')):
+        for link in os.listdir(self._path("apps")):
             try:
                 app = self.get_app(link)
                 if app is not None:
@@ -222,15 +230,15 @@ class Registry(object):
                 continue
         return rv
 
-    def get_app(self, app_id, version='latest'):
+    def get_app(self, app_id, version="latest"):
         try:
-            with open(self._path('apps', app_id, '%s.json' % version)) as f:
+            with open(self._path("apps", app_id, "%s.json" % version)) as f:
                 return json.load(f)
         except (IOError, OSError):
             pass
 
     def get_marketing_slugs(self):
-        with open(self._path('misc', 'marketing-slugs.json')) as f:
+        with open(self._path("misc", "marketing-slugs.json")) as f:
             return json.load(f)
 
     def resolve_marketing_slug(self, slug):
@@ -239,25 +247,25 @@ class Registry(object):
         if data is None:
             return
         target = None
-        if data['type'] == 'sdk':
-            target = self.get_sdk(data['target'])
-        elif data['type'] == 'package':
-            target = self.get_package(data['target'])
-        elif data['type'] == 'integration':
-            if data.get('sdk'):
-                package = self.get_sdk(data['sdk'])
-            elif data.get('package'):
-                package = self.get_package(data['package'])
+        if data["type"] == "sdk":
+            target = self.get_sdk(data["target"])
+        elif data["type"] == "package":
+            target = self.get_package(data["target"])
+        elif data["type"] == "integration":
+            if data.get("sdk"):
+                package = self.get_sdk(data["sdk"])
+            elif data.get("package"):
+                package = self.get_package(data["package"])
             else:
                 package = None
             if package is not None:
                 target = {
-                    'package': package,
-                    'integration': data['integration'],
+                    "package": package,
+                    "integration": data["integration"],
                 }
         return {
-            'definition': data,
-            'target': target,
+            "definition": data,
+            "target": target,
         }
 
 
@@ -267,7 +275,7 @@ def is_caching_enabled():
         return True
     elif cache_env == "0":
         return False
-    return os.getenv('FLASK_ENV') == "production"
+    return os.getenv("FLASK_ENV") == "production"
 
 
 def return_cached():
@@ -275,7 +283,7 @@ def return_cached():
         response = cache.get(request.path)
         if response:
             metrics.increment("cache_hit")
-            response.headers['X-From-Cache'] = '1'
+            response.headers["X-From-Cache"] = "1"
             return response
     metrics.increment("cache_miss")
 
@@ -290,7 +298,7 @@ def cache_response(response):
 
 
 def set_cache_enabled(app, enable: bool):
-    app.config['CACHE_ENABLED'] = enable
+    app.config["CACHE_ENABLED"] = enable
 
     assert type(enable) == bool
     if enable:
@@ -298,8 +306,48 @@ def set_cache_enabled(app, enable: bool):
         app.after_request(cache_response)
 
 
+def find_download_url(app_info, package, arch, platform):
+    package = package.replace("_", "-").lower().split("-")
+    for url in app_info["file_urls"].values():
+        normalized_url = url.lower()
+        if normalized_url.endswith(".exe"):
+            normalized_url = normalized_url[:-4]
+        parts = normalized_url.split("/")[-1].split("-")
+        if (
+            len(parts) > 2
+            and parts[:-2] == package
+            and parts[-1].replace("_", "-") == arch.lower().replace("_", "-")
+            and parts[-2] == platform.lower()
+        ):
+            return url
+
+
+def make_digest(checksums):
+    rv = []
+    for algo, value in (checksums or {}).items():
+        if algo.endswith("-hex"):
+            rv.append(
+                "%s=%s"
+                % (
+                    algo[:-4],
+                    binascii.b2a_base64(binascii.a2b_hex(value), newline=False).decode(
+                        "utf-8"
+                    ),
+                )
+            )
+        elif algo.endswith("-base64"):
+            rv.append("%s=%s" % (algo[:-7], value))
+    return ",".join(rv)
+
+
+def get_url_checksums(app_info, url):
+    for file_info in (app_info.get("files") or {}).values():
+        if file_info["url"] == url:
+            return file_info.get("checksums")
+
+
 app = RegistryFlask(__name__)
-app.config.from_envvar('APISERVER_CONFIG', silent=True)
+app.config.from_envvar("APISERVER_CONFIG", silent=True)
 
 # Must come before the caching callbacks otherwise it will never be called for
 # request served by the caching callback.
@@ -309,7 +357,7 @@ app.enable_cache = partial(set_cache_enabled, app)
 app.enable_cache(is_caching_enabled())
 
 
-@app.route('/packages/<path:package>/<version>')
+@app.route("/packages/<path:package>/<version>")
 def get_package_version(package, version):
     pkg_info = registry.get_package(package, version)
     if pkg_info is None:
@@ -317,23 +365,25 @@ def get_package_version(package, version):
     return ApiResponse(pkg_info)
 
 
-@app.route('/packages/<path:package>/versions')
+@app.route("/packages/<path:package>/versions")
 def get_package_versions(package):
     latest_pkg_info = registry.get_package(package)
     if latest_pkg_info is None:
         abort(404)
-    return ApiResponse({
-        'latest': latest_pkg_info,
-        'versions': registry.get_package_versions(package),
-    })
+    return ApiResponse(
+        {
+            "latest": latest_pkg_info,
+            "versions": registry.get_package_versions(package),
+        }
+    )
 
 
-@app.route('/marketing-slugs')
+@app.route("/marketing-slugs")
 def get_marketing_slugs():
     return ApiResponse(dict(slugs=sorted(registry.get_marketing_slugs().keys())))
 
 
-@app.route('/marketing-slugs/<slug>')
+@app.route("/marketing-slugs/<slug>")
 def resolve_marketing_slugs(slug):
     rv = registry.resolve_marketing_slug(slug)
     if rv is None:
@@ -341,13 +391,13 @@ def resolve_marketing_slugs(slug):
     return ApiResponse(rv)
 
 
-@app.route('/sdks')
+@app.route("/sdks")
 def get_sdk_summary():
-    strict = request.args.get('strict', '').lower() in TRUTHY_VALUES
+    strict = request.args.get("strict", "").lower() in TRUTHY_VALUES
     return ApiResponse(registry.get_sdks(strict=strict))
 
 
-@app.route('/sdks/<sdk_id>/<version>')
+@app.route("/sdks/<sdk_id>/<version>")
 def get_sdk_version(sdk_id, version):
     pkg_info = registry.get_sdk(sdk_id, version)
     if pkg_info is None:
@@ -355,42 +405,57 @@ def get_sdk_version(sdk_id, version):
     return ApiResponse(pkg_info)
 
 
-@app.route('/sdks/<sdk_id>/versions')
+@app.route("/sdks/<sdk_id>/versions")
 def get_sdk_versions(sdk_id):
     latest_pkg_info = registry.get_sdk(sdk_id)
     if latest_pkg_info is None:
         abort(404)
-    return ApiResponse({
-        'latest': latest_pkg_info,
-        'versions': registry.get_package_versions(latest_pkg_info.canonical),
-    })
+    return ApiResponse(
+        {
+            "latest": latest_pkg_info,
+            "versions": registry.get_package_versions(latest_pkg_info.canonical),
+        }
+    )
 
 
-@app.route('/packages')
+@app.route("/packages")
 def get_package_summary():
-    strict = request.args.get('strict', '').lower() in TRUTHY_VALUES
+    strict = request.args.get("strict", "").lower() in TRUTHY_VALUES
     return ApiResponse(registry.get_packages(strict=strict))
 
 
-@app.route('/apps')
+@app.route("/apps")
 def get_app_summary():
     return ApiResponse(registry.get_apps())
 
 
-@app.route('/apps/<app_id>/<version>')
+@app.route("/apps/<app_id>/<version>")
 def get_app_version(app_id, version):
     app_info = registry.get_app(app_id, version)
     if app_info is None:
         abort(404)
+    if request.args.get("response") == "download_url":
+        arch = request.args["arch"]
+        platform = request.args["platform"]
+        package = request.args["package"]
+        url = find_download_url(app_info, package, arch, platform)
+        if url is None:
+            abort(404)
+        checksums = get_url_checksums(app_info, url)
+        rv = redirect(url)
+        digest = make_digest(checksums)
+        if digest:
+            rv.headers["Digest"] = digest
+        return rv
     return ApiResponse(app_info)
 
 
-@app.route('/healthz')
+@app.route("/healthz")
 def healthcheck():
     return "ok\n", 200
 
 
-@app.route('/aws-lambda-layers')
+@app.route("/aws-lambda-layers")
 def aws_layers():
     return ApiResponse(registry.get_aws_lambda_layers())
 

--- a/api-server/apiserver.py
+++ b/api-server/apiserver.py
@@ -434,7 +434,7 @@ def get_app_version(app_id, version):
     app_info = registry.get_app(app_id, version)
     if app_info is None:
         abort(404)
-    if request.args.get("response") == "download_url":
+    if request.args.get("response") == "download":
         arch = request.args["arch"]
         platform = request.args["platform"]
         package = request.args["package"]

--- a/api-server/tests/test_routes.py
+++ b/api-server/tests/test_routes.py
@@ -1,13 +1,12 @@
-
 import pytest
 
 
 def test_caching_disabled(client):
-    assert client.application.config['CACHE_ENABLED'] is False
+    assert client.application.config["CACHE_ENABLED"] is False
 
 
 def test_route_root_not_found(client):
-    response = client.get('/')
+    response = client.get("/")
 
     assert response.status_code == 404
 
@@ -15,65 +14,81 @@ def test_route_root_not_found(client):
 @pytest.mark.parametrize(
     "sdks_url",
     [
-        '/sdks',
-        '/sdks?strict=1',
+        "/sdks",
+        "/sdks?strict=1",
     ],
-    ids=["non_strict", "strict"]
+    ids=["non_strict", "strict"],
 )
 def test_route_sdks(client, sdks_url):
     response = client.get(sdks_url)
 
     assert response.status_code == 200
     data = response.get_json()
-    assert data['sentry.python']['canonical'] == 'pypi:sentry-sdk'
+    assert data["sentry.python"]["canonical"] == "pypi:sentry-sdk"
     # ":" should work properly as a separator
-    assert data['sentry.java']['canonical'] == 'maven:io.sentry:sentry'
+    assert data["sentry.java"]["canonical"] == "maven:io.sentry:sentry"
 
 
 def test_routes_sdk_single_latest(client):
-    response = client.get('/sdks/sentry.python/latest')
+    response = client.get("/sdks/sentry.python/latest")
 
     assert response.status_code == 200
     data = response.get_json()
-    assert data['canonical'] == 'pypi:sentry-sdk'
+    assert data["canonical"] == "pypi:sentry-sdk"
 
 
 @pytest.mark.parametrize(
     "packages_url",
     [
-        '/packages',
-        '/packages?strict=1',
+        "/packages",
+        "/packages?strict=1",
     ],
-    ids=["non_strict", "strict"]
+    ids=["non_strict", "strict"],
 )
 def test_route_packages(client, packages_url):
     response = client.get(packages_url)
 
     assert response.status_code == 200
     data = response.get_json()
-    assert data['pypi:sentry-sdk']['canonical'] == 'pypi:sentry-sdk'
+    assert data["pypi:sentry-sdk"]["canonical"] == "pypi:sentry-sdk"
     # ":" should work properly as a separator
-    assert data['maven:io.sentry:sentry']['canonical'] == 'maven:io.sentry:sentry'
+    assert data["maven:io.sentry:sentry"]["canonical"] == "maven:io.sentry:sentry"
 
 
 def test_route_apps(client):
-    response = client.get('/apps')
+    response = client.get("/apps")
 
     assert response.status_code == 200
     data = response.get_json()
-    assert data['sentry-cli']
+    assert data["sentry-cli"]
+
+
+def test_download_app(client):
+    response = client.get(
+        "/apps/sentry-cli/2.0.0?response=download_url&platform=windows&arch=x86-64&package=sentry-cli"
+    )
+
+    assert response.status_code == 302
+    assert (
+        response.headers["digest"]
+        == "sha256=XH6zBy7cSQHQIJUVWw0bMMADxTsl5KoN0hsx5RDBveI="
+    )
+    assert (
+        response.headers["location"]
+        == "https://downloads.sentry-cdn.com/sentry-cli/2.0.0/sentry-cli-Windows-x86_64.exe"
+    )
 
 
 def test_route_marketing_slugs(client):
-    response = client.get('/marketing-slugs')
+    response = client.get("/marketing-slugs")
 
     assert response.status_code == 200
     data = response.get_json()
-    assert 'browser' in data['slugs']
+    assert "browser" in data["slugs"]
 
 
 def test_healthcheck(client):
-    response = client.get('/healthz')
+    response = client.get("/healthz")
 
     assert response.status_code == 200
-    assert response.data == b'ok\n'
+    assert response.data == b"ok\n"

--- a/api-server/tests/test_routes.py
+++ b/api-server/tests/test_routes.py
@@ -65,7 +65,7 @@ def test_route_apps(client):
 
 def test_download_app(client):
     response = client.get(
-        "/apps/sentry-cli/2.0.0?response=download_url&platform=windows&arch=x86-64&package=sentry-cli"
+        "/apps/sentry-cli/2.0.0?response=download&platform=windows&arch=x86-64&package=sentry-cli"
     )
 
     assert response.status_code == 302


### PR DESCRIPTION
This adds support for directly selecting a download link for a specific package on a specific architecture. This can later be used to build a better replacement for `get-cli`.

```
$ curl -I http://127.0.0.1:5000/apps/sentry-cli/2.0.0\?response\=download\&platform\=windows\&arch\=x86-64\&package\=sentry-cli
HTTP/1.0 302 FOUND
Content-Type: text/html; charset=utf-8
Content-Length: 365
Location: https://downloads.sentry-cdn.com/sentry-cli/2.0.0/sentry-cli-Windows-x86_64.exe
Digest: sha256=XH6zBy7cSQHQIJUVWw0bMMADxTsl5KoN0hsx5RDBveI=
Access-Control-Allow-Origin: *
Server: Werkzeug/0.16.0 Python/3.8.12
Date: Wed, 27 Apr 2022 11:14:21 GMT
```