### PR TITLE
Add .NET MAUI

### DIFF
--- a/packages/nuget/Sentry.Maui/3.18.0-preview.1.json
+++ b/packages/nuget/Sentry.Maui/3.18.0-preview.1.json
@@ -1,0 +1,8 @@
+{
+  "name": "Sentry.Maui",
+  "canonical": "nuget:Sentry.Maui",
+  "version": "3.18.0-preview.1",
+  "package_url": "https://www.nuget.org/packages/Sentry.Maui",
+  "repo_url": "https://github.com/getsentry/sentry-dotnet",
+  "main_docs_url": "https://docs.sentry.io/platforms/dotnet/maui"
+}

--- a/packages/nuget/Sentry.Maui/3.18.0-preview.1.json
+++ b/packages/nuget/Sentry.Maui/3.18.0-preview.1.json
@@ -4,5 +4,5 @@
   "version": "3.18.0-preview.1",
   "package_url": "https://www.nuget.org/packages/Sentry.Maui",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
-  "main_docs_url": "https://docs.sentry.io/platforms/dotnet/maui"
+  "main_docs_url": "https://docs.sentry.io/platforms/dotnet/guides/maui/"
 }

--- a/packages/nuget/Sentry.Maui/3.18.json
+++ b/packages/nuget/Sentry.Maui/3.18.json
@@ -1,0 +1,1 @@
+3.18.0-preview.1.json

--- a/packages/nuget/Sentry.Maui/3.json
+++ b/packages/nuget/Sentry.Maui/3.json
@@ -1,0 +1,1 @@
+3.18.0-preview.1.json

--- a/packages/nuget/Sentry.Maui/latest.json
+++ b/packages/nuget/Sentry.Maui/latest.json
@@ -1,0 +1,1 @@
+3.18.0-preview.1.json

--- a/sdks/sentry.dotnet.maui/Sentry.Maui
+++ b/sdks/sentry.dotnet.maui/Sentry.Maui
@@ -1,0 +1,1 @@
+../packages/nuget/Sentry.Maui


### PR DESCRIPTION
First release of the `sentry.dotnet.maui` SDK

(Wait to merge this until we publish it to Nuget)