### PR TITLE
add api docs urls for dart/flutter 7.13.2

### DIFF
--- a/packages/pub/sentry/7.13.2.json
+++ b/packages/pub/sentry/7.13.2.json
@@ -4,5 +4,6 @@
   "version": "7.13.2",
   "package_url": "https://pub.dev/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-dart",
-  "main_docs_url": "https://docs.sentry.io/platforms/dart/"
+  "main_docs_url": "https://docs.sentry.io/platforms/dart/",
+  "api_docs_url": "https://pub.dev/documentation/sentry/latest/"
 }

--- a/packages/pub/sentry_flutter/7.13.2.json
+++ b/packages/pub/sentry_flutter/7.13.2.json
@@ -4,5 +4,6 @@
   "version": "7.13.2",
   "package_url": "https://pub.dev/packages/sentry_flutter",
   "repo_url": "https://github.com/getsentry/sentry-dart",
-  "main_docs_url": "https://docs.sentry.io/platforms/flutter/"
+  "main_docs_url": "https://docs.sentry.io/platforms/flutter/",
+  "api_docs_url": "https://pub.dev/documentation/sentry_flutter/latest/"
 }


### PR DESCRIPTION
add api docs urls for dart/flutter 7.13.2. we'll automate this going forward see https://github.com/getsentry/sentry-release-registry/pull/132#issuecomment-1829393102