### PR TITLE
feat: Add `api_docs_url` for dart/flutter packages

### DIFF
--- a/packages/pub/sentry_dio/7.17.0.json
+++ b/packages/pub/sentry_dio/7.17.0.json
@@ -4,5 +4,6 @@
   "version": "7.17.0",
   "package_url": "https://pub.dev/packages/sentry_dio",
   "repo_url": "https://github.com/getsentry/sentry-dart",
-  "main_docs_url": "https://docs.sentry.io/platforms/dart/"
+  "main_docs_url": "https://docs.sentry.io/platforms/dart/",
+  "api_docs_url": "https://pub.dev/documentation/sentry_dio/latest/"
 }

--- a/packages/pub/sentry_drift/7.17.0.json
+++ b/packages/pub/sentry_drift/7.17.0.json
@@ -4,5 +4,6 @@
   "version": "7.17.0",
   "package_url": "https://pub.dev/packages/sentry_drift",
   "repo_url": "https://github.com/getsentry/sentry-dart",
-  "main_docs_url": "https://docs.sentry.io/platforms/flutter/"
+  "main_docs_url": "https://docs.sentry.io/platforms/flutter/",
+  "api_docs_url": "https://pub.dev/documentation/sentry_drift/latest/"
 }

--- a/packages/pub/sentry_hive/7.17.0.json
+++ b/packages/pub/sentry_hive/7.17.0.json
@@ -4,5 +4,6 @@
   "version": "7.17.0",
   "package_url": "https://pub.dev/packages/sentry_hive",
   "repo_url": "https://github.com/getsentry/sentry-dart",
-  "main_docs_url": "https://docs.sentry.io/platforms/flutter/"
+  "main_docs_url": "https://docs.sentry.io/platforms/flutter/",
+  "api_docs_url": "https://pub.dev/documentation/sentry_hive/latest/"
 }

--- a/packages/pub/sentry_sqflite/7.17.0.json
+++ b/packages/pub/sentry_sqflite/7.17.0.json
@@ -4,5 +4,6 @@
   "version": "7.17.0",
   "package_url": "https://pub.dev/packages/sentry_sqflite",
   "repo_url": "https://github.com/getsentry/sentry-dart",
-  "main_docs_url": "https://docs.sentry.io/platforms/flutter/"
+  "main_docs_url": "https://docs.sentry.io/platforms/flutter/",
+  "api_docs_url": "https://pub.dev/documentation/sentry_sqflite/latest/"
 }


### PR DESCRIPTION
once https://github.com/getsentry/sentry-docs/pull/9398 is merged, the api docs urls for packages will be shown correctly