### PR TITLE
powershell is part of dotnet

### DIFF
--- a/sdks/sentry.dotnet.powershell
+++ b/sdks/sentry.dotnet.powershell
@@ -1,0 +1,1 @@
+../packages/psgallery/Sentry


### PR DESCRIPTION
For SDKs that are built on top of another, we append the name.

powershell is based on .NET, and we renamed it as such:

* https://github.com/getsentry/sentry-powershell/pull/42