### PR TITLE
feat(cocoa): Add cocoapods package-url for all cocoa releases

### DIFF
--- a/packages/cocoapods/sentry-cocoa/4.1.0.json
+++ b/packages/cocoapods/sentry-cocoa/4.1.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.1.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2018-10-03T13:11:27.000Z"

--- a/packages/cocoapods/sentry-cocoa/4.1.1.json
+++ b/packages/cocoapods/sentry-cocoa/4.1.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.1.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2018-12-03T13:06:22.000Z"

--- a/packages/cocoapods/sentry-cocoa/4.1.2.json
+++ b/packages/cocoapods/sentry-cocoa/4.1.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.1.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2019-01-17T13:12:35.000Z"

--- a/packages/cocoapods/sentry-cocoa/4.1.3.json
+++ b/packages/cocoapods/sentry-cocoa/4.1.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.1.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2019-01-17T14:14:07.000Z"

--- a/packages/cocoapods/sentry-cocoa/4.2.0.json
+++ b/packages/cocoapods/sentry-cocoa/4.2.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.2.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2019-02-04T08:15:12.000Z"

--- a/packages/cocoapods/sentry-cocoa/4.2.1.json
+++ b/packages/cocoapods/sentry-cocoa/4.2.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.2.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2019-02-14T14:53:58.000Z"

--- a/packages/cocoapods/sentry-cocoa/4.3.0.json
+++ b/packages/cocoapods/sentry-cocoa/4.3.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.3.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2019-03-12T10:51:45.000Z"

--- a/packages/cocoapods/sentry-cocoa/4.3.1.json
+++ b/packages/cocoapods/sentry-cocoa/4.3.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.3.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2019-03-15T09:43:57.000Z"

--- a/packages/cocoapods/sentry-cocoa/4.4.1.json
+++ b/packages/cocoapods/sentry-cocoa/4.4.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.4.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2019-10-24T12:14:28.000Z"

--- a/packages/cocoapods/sentry-cocoa/4.5.0.json
+++ b/packages/cocoapods/sentry-cocoa/4.5.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "4.5.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/clients/cocoa",
   "created_at": "2020-03-09T08:40:22.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.0.0-beta.6.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.0-beta.6.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.0-beta.6",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.0.0-rc.1.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.0-rc.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.0-rc.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.0.0.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.0.1.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.0.2.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.0.3.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.0.4.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.0.5.json
+++ b/packages/cocoapods/sentry-cocoa/5.0.5.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.0.5",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.0.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.1.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.10-beta.0.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.10-beta.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.10-beta.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.10.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.10.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.10",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:16:20.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.2.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.3.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.4.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.5.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.5.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.5",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.6.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.6.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.6",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.7.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.7.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.7",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.8.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.8.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.8",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.1.9.json
+++ b/packages/cocoapods/sentry-cocoa/5.1.9.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.1.9",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-22T12:33:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.2.0.json
+++ b/packages/cocoapods/sentry-cocoa/5.2.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.2.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-07-30T02:00:14.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.2.1.json
+++ b/packages/cocoapods/sentry-cocoa/5.2.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.2.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-08-21T16:12:13.000Z"

--- a/packages/cocoapods/sentry-cocoa/5.2.2.json
+++ b/packages/cocoapods/sentry-cocoa/5.2.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "5.2.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-08-26T18:26:27.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.0.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-10-01T15:29:04.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.1.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-10-05T14:38:52.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.10.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.10.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.10",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-11-26T09:59:13.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.11.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.11.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.11",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-12-09T15:32:24.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.12.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.12.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.12",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-12-15T13:37:26.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.2.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-10-14T09:33:14.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.3.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-10-14T10:25:47.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.4.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-10-20T16:30:32.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.5.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.5.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.5",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-10-22T16:15:51.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.6.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.6.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.6",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-10-23T12:42:13.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.7.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.7.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.7",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-11-02T10:08:56.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.8.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.8.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.8",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-11-10T14:37:12.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.0.9.json
+++ b/packages/cocoapods/sentry-cocoa/6.0.9.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.0.9",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2020-11-12T15:15:21.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.1.0.json
+++ b/packages/cocoapods/sentry-cocoa/6.1.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.1.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-01-11T09:44:54.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.1.1.json
+++ b/packages/cocoapods/sentry-cocoa/6.1.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.1.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-01-14T09:13:16.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.1.2.json
+++ b/packages/cocoapods/sentry-cocoa/6.1.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.1.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-01-14T18:35:59.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.1.3.json
+++ b/packages/cocoapods/sentry-cocoa/6.1.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.1.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-01-18T16:08:48.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.1.4.json
+++ b/packages/cocoapods/sentry-cocoa/6.1.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.1.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-01-22T12:06:22.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.2.0.json
+++ b/packages/cocoapods/sentry-cocoa/6.2.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.2.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-02-15T15:31:37.000Z"

--- a/packages/cocoapods/sentry-cocoa/6.2.1.json
+++ b/packages/cocoapods/sentry-cocoa/6.2.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "6.2.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-02-26T09:57:25.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.0.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.0.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.0.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-04-27T16:08:21.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.0.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.0.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.0.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-04-29T10:11:31.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.0.2.json
+++ b/packages/cocoapods/sentry-cocoa/7.0.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.0.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-04-30T09:23:10.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.0.3.json
+++ b/packages/cocoapods/sentry-cocoa/7.0.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.0.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-04-30T09:52:36.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.1.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.1.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.1.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-05-19T08:15:43.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.1.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.1.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.1.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-05-26T12:32:03.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.1.2.json
+++ b/packages/cocoapods/sentry-cocoa/7.1.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.1.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-05-26T13:25:20.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.1.3.json
+++ b/packages/cocoapods/sentry-cocoa/7.1.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.1.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-05-27T14:09:29.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.1.4.json
+++ b/packages/cocoapods/sentry-cocoa/7.1.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.1.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-07-28T07:35:23.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.10.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.10.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.10.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-03-01T09:51:21.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.10.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.10.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.10.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-03-10T07:39:26.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.10.2.json
+++ b/packages/cocoapods/sentry-cocoa/7.10.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.10.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-03-14T17:51:51.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.11.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.11.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.11.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-03-21T15:14:07.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.12.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.12.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.12.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-04-05T13:23:10.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.13.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.13.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.13.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-04-14T09:25:48.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.14.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.14.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.14.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-04-27T12:55:04.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.15.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.15.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.15.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-05-09T14:45:16.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.16.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.16.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.16.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-05-24T10:05:31.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.16.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.16.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.16.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-06-13T14:06:08.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.17.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.17.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.17.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-06-17T12:25:21.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.18.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.18.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.18.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-06-21T12:22:33.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.18.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.18.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.18.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-06-24T14:43:28.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.19.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.19.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.19.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-07-04T11:44:13.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-08-17T13:34:53.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-08-19T09:35:42.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.10.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.10.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.10",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-09-13T16:43:22.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.2.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-08-20T15:44:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.3.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-08-25T13:49:01.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.4.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-08-30T19:41:38.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.5.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.5.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.5",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-08-31T07:49:44.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.6.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.6.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.6",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-08-31T15:30:07.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.7.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.7.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.7",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-09-01T16:21:19.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.8.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.8.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.8",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-09-06T09:41:14.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.2.9.json
+++ b/packages/cocoapods/sentry-cocoa/7.2.9.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.2.9",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-09-08T21:13:59.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.20.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.20.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.20.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-07-07T16:47:16.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.21.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.21.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.21.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-07-15T08:35:20.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.22.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.22.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.22.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-07-25T22:55:50.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.23.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.23.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.23.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-07-28T18:15:46.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.24.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.24.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.24.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-09-01T19:13:07.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.24.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.24.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.24.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-09-06T08:02:58.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.25.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.25.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.25.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-09-09T19:40:48.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.25.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.25.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.25.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-09-14T09:45:15.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.26.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.26.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.26.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-09-27T09:38:14.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.27.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.27.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.27.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-09-29T12:47:23.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.27.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.27.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.27.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-10-05T09:25:28.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.28.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.28.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.28.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-10-14T11:47:06.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.3.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.3.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.3.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-09-15T15:07:26.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.30.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.30.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.30.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-11-03T15:09:08.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.30.2.json
+++ b/packages/cocoapods/sentry-cocoa/7.30.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.30.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-11-10T01:23:04.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.31.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.31.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.31.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-11-14T15:52:19.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.31.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.31.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.31.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-11-16T16:02:48.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.31.2.json
+++ b/packages/cocoapods/sentry-cocoa/7.31.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.31.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-11-18T13:50:01.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.31.3.json
+++ b/packages/cocoapods/sentry-cocoa/7.31.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.31.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-11-29T16:09:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.31.4.json
+++ b/packages/cocoapods/sentry-cocoa/7.31.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.31.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-12-15T17:50:42.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.31.5.json
+++ b/packages/cocoapods/sentry-cocoa/7.31.5.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.31.5",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-12-22T19:48:35.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.4.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.4.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.4.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-09-29T12:49:43.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.4.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.4.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.4.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-09-30T14:00:30.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.4.2.json
+++ b/packages/cocoapods/sentry-cocoa/7.4.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.4.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-10-04T13:00:21.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.4.3.json
+++ b/packages/cocoapods/sentry-cocoa/7.4.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.4.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-10-07T20:07:01.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.4.4.json
+++ b/packages/cocoapods/sentry-cocoa/7.4.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.4.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-10-12T17:32:58.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.4.5.json
+++ b/packages/cocoapods/sentry-cocoa/7.4.5.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.4.5",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-10-14T11:26:29.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.4.6.json
+++ b/packages/cocoapods/sentry-cocoa/7.4.6.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.4.6",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-10-18T08:44:17.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.4.7.json
+++ b/packages/cocoapods/sentry-cocoa/7.4.7.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.4.7",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-10-21T18:01:55.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.4.8.json
+++ b/packages/cocoapods/sentry-cocoa/7.4.8.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.4.8",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-10-25T14:31:00.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.5.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.5.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.5.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-10-29T08:24:35.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.5.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.5.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.5.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-11-04T11:40:55.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.5.2.json
+++ b/packages/cocoapods/sentry-cocoa/7.5.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.5.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-11-08T12:50:51.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.5.3.json
+++ b/packages/cocoapods/sentry-cocoa/7.5.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.5.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-11-23T17:19:38.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.5.4.json
+++ b/packages/cocoapods/sentry-cocoa/7.5.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.5.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-11-30T11:32:47.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.6.1.json
+++ b/packages/cocoapods/sentry-cocoa/7.6.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.6.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-12-08T04:00:34.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.7.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.7.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.7.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2021-12-16T10:33:00.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.8.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.8.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.8.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-01-04T13:06:30.000Z"

--- a/packages/cocoapods/sentry-cocoa/7.9.0.json
+++ b/packages/cocoapods/sentry-cocoa/7.9.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "7.9.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2022-01-17T15:53:00.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.0.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.0.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.0.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-01-16T16:04:27.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.1.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.1.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.1.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-01-30T16:23:30.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.10.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.10.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.10.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-08-17T12:38:20.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.11.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.11.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.11.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-09-04T16:28:26.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.12.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.12.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.12.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-09-19T08:27:26.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.13.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.13.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.13.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-09-25T10:15:28.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.13.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.13.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.13.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-10-12T09:40:44.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.14.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.14.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.14.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-10-18T16:33:08.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.14.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.14.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.14.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-10-18T23:13:32.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.14.2.json
+++ b/packages/cocoapods/sentry-cocoa/8.14.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.14.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-10-24T09:13:21.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.15.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.15.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.15.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-11-07T17:27:21.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.15.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.15.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.15.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-11-08T11:13:57.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.15.2.json
+++ b/packages/cocoapods/sentry-cocoa/8.15.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.15.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.16.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.16.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.16.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.16.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.16.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.16.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.17.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.17.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.17.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.17.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.17.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.17.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.17.2.json
+++ b/packages/cocoapods/sentry-cocoa/8.17.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.17.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.18.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.18.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.18.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.19.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.19.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.19.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.2.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.2.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.2.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-02-23T13:06:00.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.20.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.20.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.20.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.21.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.21.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.21.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.22.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.22.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.22.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.22.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.22.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.22.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.22.2.json
+++ b/packages/cocoapods/sentry-cocoa/8.22.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.22.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.22.3.json
+++ b/packages/cocoapods/sentry-cocoa/8.22.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.22.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.22.4.json
+++ b/packages/cocoapods/sentry-cocoa/8.22.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.22.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.23.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.23.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.23.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.24.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.24.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.24.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.25.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.25.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.25.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.25.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.25.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.25.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.25.2.json
+++ b/packages/cocoapods/sentry-cocoa/8.25.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.25.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.26.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.26.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.26.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.27.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.27.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.27.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.28.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.28.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.28.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.29.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.29.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.29.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.29.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.29.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.29.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.3.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.3.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.3.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-03-07T10:48:03.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.3.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.3.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.3.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-03-14T23:11:35.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.3.2.json
+++ b/packages/cocoapods/sentry-cocoa/8.3.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.3.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-03-21T14:17:55.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.3.3.json
+++ b/packages/cocoapods/sentry-cocoa/8.3.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.3.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-03-24T12:29:45.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.30.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.30.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.30.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.30.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.30.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.30.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.31.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.31.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.31.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.31.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.31.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.31.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.32.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.32.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.32.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.33.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.33.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.33.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.34.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.34.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.34.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.35.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.35.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.35.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.35.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.35.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.35.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.36.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.36.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.36.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.37.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.37.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.37.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "categories": [

--- a/packages/cocoapods/sentry-cocoa/8.4.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.4.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.4.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-04-04T13:31:00.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.5.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.5.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.5.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-04-18T08:13:19.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.6.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.6.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.6.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-04-28T21:33:36.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.7.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.7.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.7.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-05-09T09:11:32.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.7.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.7.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.7.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-05-15T11:18:05.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.7.2.json
+++ b/packages/cocoapods/sentry-cocoa/8.7.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.7.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-05-16T16:11:13.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.7.3.json
+++ b/packages/cocoapods/sentry-cocoa/8.7.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.7.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-05-25T12:07:22.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.7.4.json
+++ b/packages/cocoapods/sentry-cocoa/8.7.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.7.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-06-14T10:35:53.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.8.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.8.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.8.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-06-15T12:19:30.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.9.0.json
+++ b/packages/cocoapods/sentry-cocoa/8.9.0.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.9.0",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-07-13T11:30:08.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.9.1.json
+++ b/packages/cocoapods/sentry-cocoa/8.9.1.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.9.1",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-07-14T09:49:35.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.9.2.json
+++ b/packages/cocoapods/sentry-cocoa/8.9.2.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.9.2",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-07-20T14:59:58.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.9.3.json
+++ b/packages/cocoapods/sentry-cocoa/8.9.3.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.9.3",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-07-24T19:18:15.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.9.4.json
+++ b/packages/cocoapods/sentry-cocoa/8.9.4.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.9.4",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-08-03T22:55:43.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.9.5.json
+++ b/packages/cocoapods/sentry-cocoa/8.9.5.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.9.5",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-08-14T19:08:01.000Z"

--- a/packages/cocoapods/sentry-cocoa/8.9.6.json
+++ b/packages/cocoapods/sentry-cocoa/8.9.6.json
@@ -2,6 +2,7 @@
   "name": "Sentry Cocoa",
   "canonical": "cocoapods:sentry-cocoa",
   "version": "8.9.6",
+  "package_url": "https://cocoapods.org/pods/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-cocoa",
   "main_docs_url": "https://docs.sentry.io/platforms/cocoa/",
   "created_at": "2023-08-16T08:28:28.000Z"


### PR DESCRIPTION
The intention is that the cocoapods canonical URL under `Package Details` now actually links to the cocoapods page like it does e.g. on Flutter (now):
![Screenshot 2024-10-07 at 19 26 27](https://github.com/user-attachments/assets/eab5eb83-2306-4e9d-981e-7f88d1fe0dff)

iOS (before)
![Screenshot 2024-10-07 at 19 26 35](https://github.com/user-attachments/assets/9a399cf1-6865-4b7d-a2a7-2873bb6cc959)
