### PR TITLE
chore(api-docs): add API docs URL to elixir versions

### DIFF
--- a/packages/hex/sentry/10.0.0.json
+++ b/packages/hex/sentry/10.0.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.0.1.json
+++ b/packages/hex/sentry/10.0.1.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.0.2.json
+++ b/packages/hex/sentry/10.0.2.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.0.3.json
+++ b/packages/hex/sentry/10.0.3.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.1.0.json
+++ b/packages/hex/sentry/10.1.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.2.0.json
+++ b/packages/hex/sentry/10.2.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.2.1.json
+++ b/packages/hex/sentry/10.2.1.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.3.0.json
+++ b/packages/hex/sentry/10.3.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.4.0.json
+++ b/packages/hex/sentry/10.4.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.5.0.json
+++ b/packages/hex/sentry/10.5.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.6.0.json
+++ b/packages/hex/sentry/10.6.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.6.1.json
+++ b/packages/hex/sentry/10.6.1.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.6.2.json
+++ b/packages/hex/sentry/10.6.2.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.7.0.json
+++ b/packages/hex/sentry/10.7.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.7.1.json
+++ b/packages/hex/sentry/10.7.1.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.8.0.json
+++ b/packages/hex/sentry/10.8.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/10.8.1.json
+++ b/packages/hex/sentry/10.8.1.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/9.0.0.json
+++ b/packages/hex/sentry/9.0.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],

--- a/packages/hex/sentry/9.1.0.json
+++ b/packages/hex/sentry/9.1.0.json
@@ -5,6 +5,7 @@
   "package_url": "https://hex.pm/packages/sentry",
   "repo_url": "https://github.com/getsentry/sentry-elixir",
   "main_docs_url": "https://docs.sentry.io/platforms/elixir",
+  "api_docs_url": "https://hexdocs.pm/sentry/",
   "categories": [
     "server"
   ],


### PR DESCRIPTION
This will lead to the API docs URL being shown in our docs for Elixir (similar to this for Java):

<img width="238" alt="Screenshot 2025-02-12 at 17 01 15" src="https://github.com/user-attachments/assets/353704d1-c0d6-40dd-ba14-c6bd8fd55980" />
