### PR TITLE
chore: switch from uwsgi to granian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ COPY api-server/requirements*.txt api-server/setup.py api-server/
 
 RUN cd api-server && pip install -e .
 
+RUN pip install granian==2.3.0
+
 COPY . .
 
 RUN chown -R registry:registry ./
@@ -40,4 +42,4 @@ EXPOSE 5030
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-CMD [ "mywsgi", "apiserver:app", "0.0.0.0:5030" ]
+CMD [ "granian", "--interface", "wsgi", "--host", "0.0.0.0", "--port", "5030", "apiserver:app" ]

--- a/api-server/requirements-base.txt
+++ b/api-server/requirements-base.txt
@@ -1,8 +1,6 @@
 flask==1.1.4
 semver==2.8.1
 sentry-sdk[flask]==0.9.5
-uwsgi==2.0.28
-mywsgi==1.0.3
 Werkzeug==0.16.0
 datadog==0.37.1
 markupsafe==2.0.1


### PR DESCRIPTION
Temporarily switch from `mywsgi/uwsgi` to `granian` in order to verify whether it solves the *weird memory usage shape* we see in charts.