### PR TITLE
chore: bump dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,6 @@ COPY api-server/requirements*.txt api-server/setup.py api-server/
 
 RUN cd api-server && pip install -e .
 
-RUN pip install granian==2.3.0
-
 COPY . .
 
 RUN chown -R registry:registry ./
@@ -42,4 +40,4 @@ EXPOSE 5030
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-CMD [ "granian", "--interface", "wsgi", "--host", "0.0.0.0", "--port", "5030", "apiserver:app" ]
+CMD [ "granian", "--interface", "wsgi", "--host", "0.0.0.0", "apiserver:app" ]

--- a/api-server/apiserver.py
+++ b/api-server/apiserver.py
@@ -5,10 +5,10 @@ from functools import partial
 from datadog import initialize as datadog_initialize, statsd
 
 import sentry_sdk
+from cachelib import SimpleCache
 from flask import Flask, json, abort, jsonify, request, redirect
 from semver import VersionInfo
 from sentry_sdk.integrations.flask import FlaskIntegration
-from werkzeug.contrib.cache import SimpleCache
 
 TRUTHY_VALUES = {"1", "true", "yes"}
 

--- a/api-server/requirements-base.txt
+++ b/api-server/requirements-base.txt
@@ -1,6 +1,7 @@
-flask==1.1.4
-semver==2.8.1
-sentry-sdk[flask]==0.9.5
-Werkzeug==0.16.0
+cachelib==0.13.0
 datadog==0.37.1
-markupsafe==2.0.1
+flask==2.1.3
+granian==2.3.0
+semver==2.8.1
+sentry-sdk[flask]==2.29.1
+werkzeug==2.3.8


### PR DESCRIPTION
As per title, this bumps dependencies to solve the resolution conflict between `granian` and `flask`.

The pinned `flask` revision should be the latest available before they dropped `JSONEncoder` and refactored the whole `json` module. Upgrading Flask further would require refactoring the custom json implementation in `apiserver.py`.