### PR TITLE
fix: Manually restore the v9 node layer

### DIFF
--- a/aws-lambda-layers/node/9.41.0.json
+++ b/aws-lambda-layers/node/9.41.0.json
@@ -6,91 +6,91 @@
   "canonical": "aws-layer:node",
   "sdk_version": "9.41.0",
   "account_number": "943013980633",
-  "layer_name": "SentryNodeServerlessSDKv10",
+  "layer_name": "SentryNodeServerlessSDKv9",
   "regions": [
     {
       "region": "af-south-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "ap-south-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "eu-north-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "eu-west-3",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "eu-south-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "eu-west-2",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "eu-west-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "ap-northeast-3",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "ap-northeast-2",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "me-south-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "ap-northeast-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "ca-central-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "sa-east-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "ap-east-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "ap-southeast-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "ap-southeast-2",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "eu-central-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "us-east-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "us-east-2",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "us-west-1",
-      "version": "2"
+      "version": "56"
     },
     {
       "region": "us-west-2",
-      "version": "2"
+      "version": "56"
     }
   ]
 }

--- a/aws-lambda-layers/node/9.42.0.json
+++ b/aws-lambda-layers/node/9.42.0.json
@@ -6,91 +6,91 @@
   "canonical": "aws-layer:node",
   "sdk_version": "9.42.0",
   "account_number": "943013980633",
-  "layer_name": "SentryNodeServerlessSDKv10",
+  "layer_name": "SentryNodeServerlessSDKv9",
   "regions": [
     {
       "region": "af-south-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "ap-south-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "eu-north-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "eu-west-3",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "eu-south-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "eu-west-2",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "eu-west-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "ap-northeast-3",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "ap-northeast-2",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "me-south-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "ap-northeast-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "ca-central-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "sa-east-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "ap-east-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "ap-southeast-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "ap-southeast-2",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "eu-central-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "us-east-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "us-east-2",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "us-west-1",
-      "version": "4"
+      "version": "56"
     },
     {
       "region": "us-west-2",
-      "version": "4"
+      "version": "56"
     }
   ]
 }

--- a/aws-lambda-layers/node/9.42.1.json
+++ b/aws-lambda-layers/node/9.42.1.json
@@ -6,91 +6,91 @@
   "canonical": "aws-layer:node",
   "sdk_version": "9.42.1",
   "account_number": "943013980633",
-  "layer_name": "SentryNodeServerlessSDKv10",
+  "layer_name": "SentryNodeServerlessSDKv9",
   "regions": [
     {
       "region": "af-south-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "ap-south-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "eu-north-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "eu-west-3",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "eu-south-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "eu-west-2",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "eu-west-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "ap-northeast-3",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "ap-northeast-2",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "me-south-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "ap-northeast-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "ca-central-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "sa-east-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "ap-east-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "ap-southeast-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "ap-southeast-2",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "eu-central-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "us-east-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "us-east-2",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "us-west-1",
-      "version": "5"
+      "version": "56"
     },
     {
       "region": "us-west-2",
-      "version": "5"
+      "version": "56"
     }
   ]
 }


### PR DESCRIPTION
After `9.40.0` we started publishing `10.0.0-alpha` releases which ended up overwriting the layer in the release registry for v9.

We manually overwrite the versions here so that the next release gets the proper v9 layer written in.

This came from a mistunderstanding of how craft handles pre-releases (assumption was: we publish to the AWS registry but not our release registry).