### PR TITLE
ref(scripts): Use Python 3

### DIFF
--- a/bin/semver.py
+++ b/bin/semver.py
@@ -156,7 +156,7 @@ class VersionInfo(object):
 
     def __repr__(self):
         s = ", ".join("%s=%r" % (key, val)
-                      for key, val in self._asdict().items())
+                      for key, val in list(self._asdict().items()))
         return "VersionInfo(%s)" % s
 
     def __str__(self):

--- a/bin/semver.py
+++ b/bin/semver.py
@@ -156,7 +156,7 @@ class VersionInfo(object):
 
     def __repr__(self):
         s = ", ".join("%s=%r" % (key, val)
-                      for key, val in list(self._asdict().items()))
+                      for key, val in self._asdict().items())
         return "VersionInfo(%s)" % s
 
     def __str__(self):

--- a/bin/sync-links
+++ b/bin/sync-links
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
 import os
 import sys
 import json


### PR DESCRIPTION
The script to run in order to add a new SDKs uses Python 2.
I don't have it installed and it seems it's complicated to install it with brew.
This changes it to use Python 3.
I've used 2to3 to check for any necessary changes and the only thing it suggests is this change in `bin/semver.py`.
I don't think that change is needed but it won't hurt either.