### PR TITLE
fix(node-core): Fix node-core symlink

### DIFF
--- a/sdks/sentry.javascript.node-core
+++ b/sdks/sentry.javascript.node-core
@@ -1,1 +1,1 @@
-packages/npm/@sentry/node-core
+../packages/npm/@sentry/node-core


### PR DESCRIPTION
I previously ran the command as `cd sdks && ln -s packages/npm/@sentry/node-core sentry.javascript.node-core` missing the `../` at the front.