### PR TITLE
chore: add least-privilege permissions to GitHub workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [master, test-me-*]
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pipelines.yml
+++ b/.github/workflows/validate-pipelines.yml
@@ -5,6 +5,9 @@ on:
     push:
         branches: [master, test-me-*]
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true


### PR DESCRIPTION
Resolves two open CodeQL alerts (`actions/missing-workflow-permissions`, medium severity) by adding workflow-level least-privilege permissions to the two flagged workflows.

## Changes

- `.github/workflows/lint.yml`: add `permissions: { contents: read }` at workflow level. The `main` job only checks out code, syncs symlinks, and runs Python tests — read-only is sufficient.
- `.github/workflows/validate-pipelines.yml`: add `permissions: { contents: read }` at workflow level. The `validate` job's existing per-job block (`contents: read`, `id-token: write` for Google OIDC) overrides the default and is unchanged. The `files-changed` job (only checkout + paths-filter) inherits the read-only default.

`.github/workflows/deploy-visualization.yml` already declares workflow-level permissions and was not flagged.

## Verification

After merge, CodeQL re-runs and the two open alerts (#2 and #7) should auto-transition to `fixed`:

```shell
gh api "/repos/getsentry/sentry-release-registry/code-scanning/alerts?per_page=100&state=open" \
  --jq '[.[] | {number, rule_id: .rule.id, path: .most_recent_instance.location.path}]'
```

Expected: `[]`.

## Notes

- No security advisories or Dependabot alerts visible to the CLI token; only the two CodeQL workflow-permission alerts were actionable.
- The full implementation plan is attached as a `git note` on the commit.
