### PR TITLE
fix(dotnet): created_at for release 6.5.0

### DIFF
--- a/packages/nuget/Sentry.AspNet/6.5.0.json
+++ b/packages/nuget/Sentry.AspNet/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.AspNet",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/aspnet",
-  "created_at": "2026-05-05T17:04:17.271Z"
+  "created_at": "2026-05-05T10:49:46.170Z"
 }

--- a/packages/nuget/Sentry.AspNetCore.Blazor.WebAssembly/6.5.0.json
+++ b/packages/nuget/Sentry.AspNetCore.Blazor.WebAssembly/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.AspNetCore.Blazor.WebAssembly",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/aspnetcore",
-  "created_at": "2026-05-05T17:04:17.271Z"
+  "created_at": "2026-05-05T10:49:46.553Z"
 }

--- a/packages/nuget/Sentry.AspNetCore.Grpc/6.5.0.json
+++ b/packages/nuget/Sentry.AspNetCore.Grpc/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.AspNetCore.Grpc",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-05T17:04:17.271Z"
+  "created_at": "2026-05-05T10:49:46.787Z"
 }

--- a/packages/nuget/Sentry.AspNetCore/6.5.0.json
+++ b/packages/nuget/Sentry.AspNetCore/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.AspNetCore",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/aspnetcore",
-  "created_at": "2026-05-05T17:04:17.270Z"
+  "created_at": "2026-05-05T10:49:47.150Z"
 }

--- a/packages/nuget/Sentry.DiagnosticSource/6.5.0.json
+++ b/packages/nuget/Sentry.DiagnosticSource/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.DiagnosticSource",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-05T17:04:17.271Z"
+  "created_at": "2026-05-05T10:49:46.430Z"
 }

--- a/packages/nuget/Sentry.EntityFramework/6.5.0.json
+++ b/packages/nuget/Sentry.EntityFramework/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.EntityFramework",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/entityframework",
-  "created_at": "2026-05-05T17:04:17.271Z"
+  "created_at": "2026-05-05T10:49:47.027Z"
 }

--- a/packages/nuget/Sentry.Extensions.AI/6.5.0.json
+++ b/packages/nuget/Sentry.Extensions.AI/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Extensions.AI",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/tracing/instrumentation/ai-agents-module/",
-  "created_at": "2026-05-05T17:04:17.271Z"
+  "created_at": "2026-05-05T10:49:45.350Z"
 }

--- a/packages/nuget/Sentry.Extensions.Logging/6.5.0.json
+++ b/packages/nuget/Sentry.Extensions.Logging/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Extensions.Logging",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/microsoft-extensions-logging",
-  "created_at": "2026-05-05T17:04:17.272Z"
+  "created_at": "2026-05-05T10:49:46.583Z"
 }

--- a/packages/nuget/Sentry.Google.Cloud.Functions/6.5.0.json
+++ b/packages/nuget/Sentry.Google.Cloud.Functions/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Google.Cloud.Functions",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/gcp-functions",
-  "created_at": "2026-05-05T17:04:17.272Z"
+  "created_at": "2026-05-05T10:49:46.753Z"
 }

--- a/packages/nuget/Sentry.Hangfire/6.5.0.json
+++ b/packages/nuget/Sentry.Hangfire/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Hangfire",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/crons/hangfire/",
-  "created_at": "2026-05-05T17:04:17.272Z"
+  "created_at": "2026-05-05T10:49:46.777Z"
 }

--- a/packages/nuget/Sentry.Log4Net/6.5.0.json
+++ b/packages/nuget/Sentry.Log4Net/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Log4Net",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-05T17:04:17.272Z"
+  "created_at": "2026-05-05T10:49:47.333Z"
 }

--- a/packages/nuget/Sentry.Maui/6.5.0.json
+++ b/packages/nuget/Sentry.Maui/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Maui",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/guides/maui/",
-  "created_at": "2026-05-05T17:04:17.272Z"
+  "created_at": "2026-05-05T10:49:47.297Z"
 }

--- a/packages/nuget/Sentry.NLog/6.5.0.json
+++ b/packages/nuget/Sentry.NLog/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.NLog",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-05T17:04:17.272Z"
+  "created_at": "2026-05-05T10:49:46.787Z"
 }

--- a/packages/nuget/Sentry.OpenTelemetry/6.5.0.json
+++ b/packages/nuget/Sentry.OpenTelemetry/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.OpenTelemetry",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/performance/instrumentation/opentelemetry/",
-  "created_at": "2026-05-05T17:04:17.272Z"
+  "created_at": "2026-05-05T10:49:46.437Z"
 }

--- a/packages/nuget/Sentry.Profiling/6.5.0.json
+++ b/packages/nuget/Sentry.Profiling/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Profiling",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/profiling/",
-  "created_at": "2026-05-05T17:04:17.272Z"
+  "created_at": "2026-05-05T10:49:47.433Z"
 }

--- a/packages/nuget/Sentry.Serilog/6.5.0.json
+++ b/packages/nuget/Sentry.Serilog/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Serilog",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-05T17:04:17.272Z"
+  "created_at": "2026-05-05T10:49:46.677Z"
 }

--- a/packages/nuget/Sentry/6.5.0.json
+++ b/packages/nuget/Sentry/6.5.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-05T17:04:17.270Z"
+  "created_at": "2026-05-05T10:49:47.480Z"
 }


### PR DESCRIPTION
### Summary

Fix the `created_at` timestamps of Release v6.5.0 of the Sentry .NET SDKs.

### Remarks

We faced some issues during release 6.5.0 of the `getsentry/sentry-dotnet` SDKs.
See
- getsentry/publish#8066
- getsentry/publish#8081

With the release on GitHub and NuGet.org succeeded, the `created_at` timestamps in the Release Registry are wrong.

This change is updating the timestamps to the actual publish date/time on NuGet.org

See e.g.
- https://www.nuget.org/packages/Sentry/6.5.0
