### PR TITLE
fix(dotnet): created_at for release 6.6.0

### DIFF
--- a/packages/nuget/Sentry.AspNet/6.6.0.json
+++ b/packages/nuget/Sentry.AspNet/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.AspNet",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/aspnet",
-  "created_at": "2026-05-27T09:32:02.557Z"
+  "created_at": "2026-05-28T09:01:07.387Z"
 }

--- a/packages/nuget/Sentry.AspNetCore.Blazor.WebAssembly/6.6.0.json
+++ b/packages/nuget/Sentry.AspNetCore.Blazor.WebAssembly/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.AspNetCore.Blazor.WebAssembly",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/aspnetcore",
-  "created_at": "2026-05-27T09:32:02.557Z"
+  "created_at": "2026-05-28T09:01:05.057Z"
 }

--- a/packages/nuget/Sentry.AspNetCore.Grpc/6.6.0.json
+++ b/packages/nuget/Sentry.AspNetCore.Grpc/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.AspNetCore.Grpc",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-27T09:32:02.557Z"
+  "created_at": "2026-05-28T09:01:07.660Z"
 }

--- a/packages/nuget/Sentry.AspNetCore/6.6.0.json
+++ b/packages/nuget/Sentry.AspNetCore/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.AspNetCore",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/aspnetcore",
-  "created_at": "2026-05-27T09:32:02.557Z"
+  "created_at": "2026-05-28T09:01:07.143Z"
 }

--- a/packages/nuget/Sentry.DiagnosticSource/6.6.0.json
+++ b/packages/nuget/Sentry.DiagnosticSource/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.DiagnosticSource",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-27T09:32:02.558Z"
+  "created_at": "2026-05-28T09:01:07.787Z"
 }

--- a/packages/nuget/Sentry.EntityFramework/6.6.0.json
+++ b/packages/nuget/Sentry.EntityFramework/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.EntityFramework",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/entityframework",
-  "created_at": "2026-05-27T09:32:02.558Z"
+  "created_at": "2026-05-28T09:01:07.743Z"
 }

--- a/packages/nuget/Sentry.Extensions.AI/6.6.0.json
+++ b/packages/nuget/Sentry.Extensions.AI/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Extensions.AI",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/tracing/instrumentation/ai-agents-module/",
-  "created_at": "2026-05-27T09:32:02.558Z"
+  "created_at": "2026-05-28T09:01:07.197Z"
 }

--- a/packages/nuget/Sentry.Extensions.Logging/6.6.0.json
+++ b/packages/nuget/Sentry.Extensions.Logging/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Extensions.Logging",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/microsoft-extensions-logging",
-  "created_at": "2026-05-27T09:32:02.558Z"
+  "created_at": "2026-05-28T09:01:05.880Z"
 }

--- a/packages/nuget/Sentry.Google.Cloud.Functions/6.6.0.json
+++ b/packages/nuget/Sentry.Google.Cloud.Functions/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Google.Cloud.Functions",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/gcp-functions",
-  "created_at": "2026-05-27T09:32:02.558Z"
+  "created_at": "2026-05-28T09:01:05.423Z"
 }

--- a/packages/nuget/Sentry.Hangfire/6.6.0.json
+++ b/packages/nuget/Sentry.Hangfire/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Hangfire",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/crons/hangfire/",
-  "created_at": "2026-05-27T09:32:02.558Z"
+  "created_at": "2026-05-28T09:01:07.357Z"
 }

--- a/packages/nuget/Sentry.Log4Net/6.6.0.json
+++ b/packages/nuget/Sentry.Log4Net/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Log4Net",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-27T09:32:02.558Z"
+  "created_at": "2026-05-28T09:01:06.570Z"
 }

--- a/packages/nuget/Sentry.Maui/6.6.0.json
+++ b/packages/nuget/Sentry.Maui/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Maui",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/guides/maui/",
-  "created_at": "2026-05-27T09:32:02.558Z"
+  "created_at": "2026-05-28T09:01:07.417Z"
 }

--- a/packages/nuget/Sentry.NLog/6.6.0.json
+++ b/packages/nuget/Sentry.NLog/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.NLog",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-27T09:32:02.558Z"
+  "created_at": "2026-05-28T09:01:07.727Z"
 }

--- a/packages/nuget/Sentry.OpenTelemetry.Exporter/6.6.0.json
+++ b/packages/nuget/Sentry.OpenTelemetry.Exporter/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.OpenTelemetry.Exporter",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/tracing/instrumentation/opentelemetry/",
-  "created_at": "2026-05-27T09:32:02.559Z"
+  "created_at": "2026-05-28T09:01:06.310Z"
 }

--- a/packages/nuget/Sentry.OpenTelemetry/6.6.0.json
+++ b/packages/nuget/Sentry.OpenTelemetry/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.OpenTelemetry",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/performance/instrumentation/opentelemetry/",
-  "created_at": "2026-05-27T09:32:02.559Z"
+  "created_at": "2026-05-28T09:01:07.560Z"
 }

--- a/packages/nuget/Sentry.Profiling/6.6.0.json
+++ b/packages/nuget/Sentry.Profiling/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Profiling",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet/profiling/",
-  "created_at": "2026-05-27T09:32:02.559Z"
+  "created_at": "2026-05-28T09:01:07.030Z"
 }

--- a/packages/nuget/Sentry.Serilog/6.6.0.json
+++ b/packages/nuget/Sentry.Serilog/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry.Serilog",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-27T09:32:02.559Z"
+  "created_at": "2026-05-28T09:01:07.697Z"
 }

--- a/packages/nuget/Sentry/6.6.0.json
+++ b/packages/nuget/Sentry/6.6.0.json
@@ -5,5 +5,5 @@
   "package_url": "https://www.nuget.org/packages/Sentry",
   "repo_url": "https://github.com/getsentry/sentry-dotnet",
   "main_docs_url": "https://docs.sentry.io/platforms/dotnet",
-  "created_at": "2026-05-27T09:32:02.556Z"
+  "created_at": "2026-05-28T09:01:09.830Z"
 }


### PR DESCRIPTION
### Summary

Fix the `created_at` timestamps of Release v6.6.0 of the Sentry .NET SDKs.

### Remarks

We faced some issues during release 6.6.0 of the `getsentry/sentry-dotnet` SDKs.
See
- getsentry/publish#8296
- getsentry/publish#8276
- getsentry/publish#8268
- getsentry/publish#8267

With the release on GitHub and NuGet.org succeeded, the `created_at` timestamps in the Release Registry are wrong.

This change is updating the timestamps to the actual publish date/time on NuGet.org

See e.g.
- https://www.nuget.org/packages/Sentry/6.6.0
